### PR TITLE
Implementation of the type adapter to the image_publisher class

### DIFF
--- a/realsense2_camera/CMakeLists.txt
+++ b/realsense2_camera/CMakeLists.txt
@@ -93,7 +93,7 @@ endif()
 
 find_package(ament_cmake REQUIRED)
 find_package(builtin_interfaces REQUIRED)
-find_package(cv_bridge REQUIRED)
+find_package(cv_bridge REQUIRED 3.3.0)
 find_package(image_transport REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_components REQUIRED)

--- a/realsense2_camera/include/base_realsense_node.h
+++ b/realsense2_camera/include/base_realsense_node.h
@@ -6,7 +6,9 @@
 #include <librealsense2/rs.hpp>
 #include <librealsense2/rsutil.h>
 #include "constants.h"
-#include <cv_bridge/cv_bridge.h>
+#include <cv_bridge/cv_bridge.hpp>
+#include <cv_bridge/cv_mat_sensor_msgs_image_type_adapter.hpp>
+
 
 #include <diagnostic_updater/diagnostic_updater.hpp>
 #include <diagnostic_updater/publisher.hpp>

--- a/realsense2_camera/include/image_publisher.h
+++ b/realsense2_camera/include/image_publisher.h
@@ -22,6 +22,7 @@ class image_publisher
 {
 public:
     virtual void publish( sensor_msgs::msg::Image::UniquePtr image_ptr ) = 0;
+    virtual void publish( std::unique_ptr<cv_bridge::ROSCvMatContainer> container_ptr ){throw std::runtime_error("This publisher does not use type adaptation");};
     virtual size_t get_subscription_count() const = 0;
     virtual ~image_publisher() = default;
     bool has_type_adapter(){ return has_type_adapter_; };
@@ -38,7 +39,7 @@ public:
                          const std::string & topic_name,
                          const rmw_qos_profile_t & qos );
     void publish( sensor_msgs::msg::Image::UniquePtr image_ptr ) override;
-    void publish( std::unique_ptr<cv_bridge::ROSCvMatContainer> container_ptr );
+    void publish( std::unique_ptr<cv_bridge::ROSCvMatContainer> container_ptr ) override;
     size_t get_subscription_count() const override;
 
 private:

--- a/realsense2_camera/include/image_publisher.h
+++ b/realsense2_camera/include/image_publisher.h
@@ -24,6 +24,10 @@ public:
     virtual void publish( sensor_msgs::msg::Image::UniquePtr image_ptr ) = 0;
     virtual size_t get_subscription_count() const = 0;
     virtual ~image_publisher() = default;
+    bool has_type_adapter(){ return has_type_adapter_; };
+    void set_type_adapter(bool value){ has_type_adapter_ = value; };
+private:
+    bool has_type_adapter_ = false;
 };
 
 // Native RCL implementation of an image publisher (needed for intra-process communication)
@@ -34,6 +38,7 @@ public:
                          const std::string & topic_name,
                          const rmw_qos_profile_t & qos );
     void publish( sensor_msgs::msg::Image::UniquePtr image_ptr ) override;
+    void publish( std::unique_ptr<cv_bridge::ROSCvMatContainer> container_ptr );
     size_t get_subscription_count() const override;
 
 private:

--- a/realsense2_camera/src/image_publisher.cpp
+++ b/realsense2_camera/src/image_publisher.cpp
@@ -13,12 +13,17 @@ image_rcl_publisher::image_rcl_publisher( rclcpp::Node & node,
     image_publisher_impl = node.create_publisher<cv_bridge::ROSCvMatContainer>(
         topic_name,
         rclcpp::QoS( rclcpp::QoSInitialization::from_rmw( qos ), qos ) );
+    set_type_adapter(true);
 }
 
 void image_rcl_publisher::publish( sensor_msgs::msg::Image::UniquePtr image_ptr )
 {
-    auto container = std::make_unique<cv_bridge::ROSCvMatContainer>(std::move(image_ptr));
-    image_publisher_impl->publish( std::move(container) );
+    image_publisher_impl->publish( std::move(image_ptr) );
+}
+
+void image_rcl_publisher::publish( std::unique_ptr<cv_bridge::ROSCvMatContainer> container_ptr )
+{
+    image_publisher_impl->publish( std::move(container_ptr) );
 }
 
 size_t image_rcl_publisher::get_subscription_count() const


### PR DESCRIPTION
This PR implements the `ROSCvMatContainer` type adapter to the `image_publisher` class. Taking into account that type adaptation is best used when intra-process communication is enabled, only the publisher used for that case is being modified.

The `image_rcl_publisher` (the one used with intra-process comm) have the method `image_rcl_publisher::publish` which takes a `sensor_msgs::msg::Image::UniquePtr` and publishes it. This PR, overloads that method to also receive a `std::unique_ptr<cv_bridge::ROSCvMatContainer>` and publishes it without creating any copies in the process.

Signed-off-by: Voldivh <eloyabmfcv@gmail.com>